### PR TITLE
Add Vanna Precompiles for Nitro 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/google/brotli.git
 [submodule "contracts"]
 	path = contracts
-	url = https://github.com/OffchainLabs/nitro-contracts.git
+	url = https://github.com/VannaLabs/nitro-contracts.git
 	branch = develop
 [submodule "arbitrator/wasm-testsuite/testsuite"]
 	path = arbitrator/wasm-testsuite/testsuite

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ COPY ./contracts/src/precompiles/ ./contracts/src/precompiles/
 COPY ./contracts/package.json ./contracts/yarn.lock ./contracts/
 COPY ./solgen/gen.go ./solgen/
 COPY ./fastcache ./fastcache
-COPY ./vanna-arb-geth ./go-ethereum
+COPY ./vanna-arb-geth ./vanna-arb-geth
 COPY --from=brotli-wasm-export / target/
 COPY --from=contracts-builder workspace/contracts/build/contracts/src/precompiles/ contracts/build/contracts/src/precompiles/
 COPY --from=contracts-builder workspace/contracts/node_modules/@offchainlabs/upgrade-executor/build/contracts/src/UpgradeExecutor.sol/UpgradeExecutor.json contracts/
@@ -176,7 +176,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y wabt
 COPY go.mod go.sum ./
-COPY vanna-arb-geth/go.mod vanna-arb-geth/go.sum vanna-arb-eth/
+COPY vanna-arb-geth/go.mod vanna-arb-geth/go.sum vanna-arb-geth/
 COPY fastcache/go.mod fastcache/go.sum fastcache/
 RUN go mod download
 COPY . ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ COPY ./contracts/src/precompiles/ ./contracts/src/precompiles/
 COPY ./contracts/package.json ./contracts/yarn.lock ./contracts/
 COPY ./solgen/gen.go ./solgen/
 COPY ./fastcache ./fastcache
-COPY ./go-ethereum ./go-ethereum
+COPY ./vanna-arb-geth ./go-ethereum
 COPY --from=brotli-wasm-export / target/
 COPY --from=contracts-builder workspace/contracts/build/contracts/src/precompiles/ contracts/build/contracts/src/precompiles/
 COPY --from=contracts-builder workspace/contracts/node_modules/@offchainlabs/upgrade-executor/build/contracts/src/UpgradeExecutor.sol/UpgradeExecutor.json contracts/
@@ -176,7 +176,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y wabt
 COPY go.mod go.sum ./
-COPY go-ethereum/go.mod go-ethereum/go.sum go-ethereum/
+COPY vanna-arb-geth/go.mod vanna-arb-geth/go.sum vanna-arb-eth/
 COPY fastcache/go.mod fastcache/go.sum fastcache/
 RUN go mod download
 COPY . ./

--- a/precompiles/ArbInferCall.go
+++ b/precompiles/ArbInferCall.go
@@ -1,0 +1,40 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package precompiles
+
+import (
+	"fmt"
+	"strings"
+
+	inference "github.com/ethereum/go-ethereum/rpc/inference"
+)
+
+// ArbGasInfo provides insight into the cost of using the rollup.
+type ArbInferCall struct {
+	Address addr // 0x11a
+}
+
+func (con *ArbInferCall) InferCall(c ctx, evm mech, input []byte) ([]byte, error) {
+	inputStr := string(input)
+	// Split string into two parts
+	inputArray := strings.Split(inputStr, "-")
+	modelName := inputArray[0]
+	inputData := inputArray[1]
+	rc := inference.NewRequestClient(5125)
+	tx := inference.InferenceTx{
+		Hash:   "0x123456789",
+		Model:  modelName,
+		Params: inputData,
+		TxType: "inference",
+	}
+	result, err := rc.Emit(tx)
+	if err != nil {
+		fmt.Println("InferCall Error", err)
+		return []byte{}, err
+	}
+
+	byteValue := make([]byte, len(result))
+	copy(byteValue, result)
+	return byteValue, nil
+}

--- a/precompiles/ArbInference.go
+++ b/precompiles/ArbInference.go
@@ -10,7 +10,7 @@ type ArbInference struct {
 	params string
 }
 
-func (con ArbStatistics) InferCall(c ctx, evm mech) (string, error) {
+func (con ArbInference) InferCall(c ctx, evm mech) (string, error) {
 	rc := inference.NewRequestClient(5125)
 	tx := inference.InferenceTx{
 		Hash:   "0x123456789",

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -540,6 +540,7 @@ func Precompiles() map[addr]ArbosPrecompile {
 	ArbGasInfo.methodsByName["GetL1RewardRecipient"].arbosVersion = 11
 	insert(MakePrecompile(templates.ArbAggregatorMetaData, &ArbAggregator{Address: hex("6d")}))
 	insert(MakePrecompile(templates.ArbStatisticsMetaData, &ArbStatistics{Address: hex("6f")}))
+	insert(MakePrecompile(templates.ArbInferCallMetaData, &ArbInferCall{Address: hex("11a")}))
 
 	eventCtx := func(gasLimit uint64, err error) *Context {
 		if err != nil {


### PR DESCRIPTION
Adds the Vanna Precompiles for Nitro using option 2 in https://docs.arbitrum.io/launch-orbit-chain/how-tos/customize-precompile

Docker builds without errors - `docker build . --tag custom-nitro-node`

Needs testing using: https://docs.arbitrum.io/launch-orbit-chain/how-tos/customize-stf#step-3-run-the-node-without-fraud-proofs. Might be easier to first test using https://docs.arbitrum.io/node-running/how-tos/local-dev-node